### PR TITLE
perf config: Tidy up the code setting buildid dir

### DIFF
--- a/tools/perf/perf.c
+++ b/tools/perf/perf.c
@@ -549,6 +549,7 @@ int main(int argc, const char **argv)
 	srandom(time(NULL));
 
 	perf_config(perf_default_config, NULL);
+	set_buildid_dir(NULL);
 
 	/* get debugfs/tracefs mount point from /proc/mounts */
 	tracing_path_mount();
@@ -572,7 +573,6 @@ int main(int argc, const char **argv)
 	}
 	if (!prefixcmp(cmd, "trace")) {
 #ifdef HAVE_LIBAUDIT_SUPPORT
-		set_buildid_dir(NULL);
 		setup_path();
 		argv[0] = "trace";
 		return cmd_trace(argc, argv, NULL);
@@ -587,7 +587,6 @@ int main(int argc, const char **argv)
 	argc--;
 	handle_options(&argv, &argc, NULL);
 	commit_pager_choice();
-	set_buildid_dir(NULL);
 
 	if (argc > 0) {
 		if (!prefixcmp(argv[0], "--"))

--- a/tools/perf/util/config.c
+++ b/tools/perf/util/config.c
@@ -540,10 +540,11 @@ void set_buildid_dir(const char *dir)
 
 	/* default to $HOME/.debug */
 	if (buildid_dir[0] == '\0') {
-		char *v = getenv("HOME");
-		if (v) {
+		char *home = getenv("HOME");
+
+		if (home) {
 			snprintf(buildid_dir, MAXPATHLEN-1, "%s/%s",
-				 v, DEBUG_CACHE_DIR);
+				 home, DEBUG_CACHE_DIR);
 		} else {
 			strncpy(buildid_dir, DEBUG_CACHE_DIR, MAXPATHLEN-1);
 		}


### PR DESCRIPTION
Add new perf_buildid_config() into perf_default_config,
bring set_buildid_dir() next to perf_default_config,
rename some variable name as more readable name and etc
in order to clean up code about buildid dir.

Cc: Jiri Olsa jolsa@kernel.org
Cc: Namhyung Kim namhyung@kernel.org
Cc: Wang Nan wangnan0@huawei.com
Signed-off-by: Taeung Song treeze.taeung@gmail.com
